### PR TITLE
Refactor Round Robin logic

### DIFF
--- a/intermediate/job_scheduling_multiple_queues/src/scheduler/algorithms/round_robin.rs
+++ b/intermediate/job_scheduling_multiple_queues/src/scheduler/algorithms/round_robin.rs
@@ -28,19 +28,25 @@ impl Scheduler for RoundRobinScheduler {
     &mut self,
     current_time: u32
   ) -> Option<Job> {
-    if let Some(mut job) = self.queue.pop_front() {
-      let run_time = job.remaining_time.min(self.time_quantum);
-      job.remaining_time -= run_time;
+    let mut idx: usize = 0;
+    while idx < self.queue.len() {
+      if self.queue[idx].arrival_time <= current_time {
+        let mut job = self.queue.remove(idx).unwrap();
+        let run_time = job.remaining_time.min(self.time_quantum);
+        job.remaining_time -= run_time;
 
-      if job.remaining_time > 0 {
-        self.queue.push_back(job);
+        if job.remaining_time > 0 {
+          self.queue.push_back(job);
+        } else {
+          job.completion_time = Some(current_time + run_time);
+        }
+
+        return Some(job)
       } else {
-        job.completion_time = Some(current_time + run_time);
+        idx += 1;
       }
-
-      Some(job)
-    } else {
-      None
     }
+
+    None
   }
 }

--- a/intermediate/job_scheduling_multiple_queues/src/tests/helper/create_job.rs
+++ b/intermediate/job_scheduling_multiple_queues/src/tests/helper/create_job.rs
@@ -1,4 +1,14 @@
-use crate::models::job::{Job, JobType};
+use crate::{
+  models::job::{Job, JobType},
+  queues::queue::{JobQueue, QueueScheduler},
+  scheduler::{
+    mlq::MLQScheduler,
+    algorithms::{
+      fcfs::FCFSScheduler,
+      round_robin::RoundRobinScheduler,
+    }
+  }
+};
 
 pub fn create_job(
   id: u32,
@@ -34,5 +44,20 @@ pub fn create_job_mlq(
     job_type,
     start_time: None,
     completion_time: None
+  }
+}
+
+pub fn create_mlq() -> MLQScheduler {
+  MLQScheduler {
+    queues: vec![
+      JobQueue {
+        level: 0,
+        scheduler: QueueScheduler::RoundRobin(RoundRobinScheduler::new(2))
+      },
+      JobQueue {
+        level: 1,
+        scheduler: QueueScheduler::FCFS(FCFSScheduler::new())
+      }
+    ],
   }
 }

--- a/intermediate/job_scheduling_multiple_queues/src/tests/test_mlq.rs
+++ b/intermediate/job_scheduling_multiple_queues/src/tests/test_mlq.rs
@@ -2,30 +2,14 @@
 mod tests {
   use crate::{
     job::JobType,
-    queue::{
-      JobQueue,
-      QueueScheduler
-    },
-    scheduler::{
-      algorithms::{fcfs::FCFSScheduler, round_robin::RoundRobinScheduler},
-      mlq::MLQScheduler, scheduler::Scheduler
-    },
-    tests::helper::create_job::create_job_mlq
+    scheduler::scheduler::Scheduler,
+    tests::helper::create_job::{create_job_mlq, create_mlq}
   };
 
   #[test]
   fn test_mlq_scheduling_order() {
-    let rr_queue = JobQueue {
-      level: 0,
-      scheduler: QueueScheduler::RoundRobin(RoundRobinScheduler::new(2))
-    };
 
-    let fcfs_queue = JobQueue {
-      level: 1,
-      scheduler: QueueScheduler::FCFS(FCFSScheduler::new())
-    };
-
-    let mut mlq = MLQScheduler { queues: vec![rr_queue, fcfs_queue] };
+    let mut mlq = create_mlq();
 
     let job1 = create_job_mlq(1, 0, 4, JobType::Foreground, 0);
     let job2 = create_job_mlq(2, 0, 3, JobType::Background, 1);
@@ -34,15 +18,56 @@ mod tests {
     mlq.add_job(job2);
 
     let result1 = mlq.schedule(0).unwrap();
-    println!("First Result: {:?}", result1);
+    // println!("First Result: {:?}", result1);
     assert_eq!(result1.id, 1);
 
     let result2 = mlq.schedule(2).unwrap();
-    println!("Second Result: {:?}", result2);
+    // println!("Second Result: {:?}", result2);
     assert_eq!(result2.id, 1);
 
     let result3 = mlq.schedule(4).unwrap(); // Now FCFS is scheduled, since RR queue is now empty
-    println!("Third Result: {:?}", result3);
+    // println!("Third Result: {:?}", result3);
     assert_eq!(result3.id, 2);
+  }
+
+  #[test]
+  fn test_mlq_fallback_to_lower_queue() {
+    let mut scheduler = create_mlq();
+
+    scheduler.add_job(create_job_mlq(1, 0, 5, JobType::Background, 1));
+
+    let job = scheduler.schedule(0).unwrap();
+    println!("MLQ: {:?}", job);
+    assert_eq!(job.id, 1);
+  }
+
+  #[test]
+  fn test_mlq_round_robin_behavior() {
+    let mut scheduler = create_mlq();
+
+    scheduler.add_job(create_job_mlq(1, 0, 5, JobType::Foreground, 0));
+
+    let job1 = scheduler.schedule(0).unwrap();
+    // println!("RT: {:?}", job1.remaining_time);
+    assert_eq!(job1.remaining_time, 3);
+
+    let job2 = scheduler.schedule(2).unwrap();
+    // println!("RT2: {:?}", job2.remaining_time);
+    assert_eq!(job2.remaining_time, 1);
+  }
+
+  #[test]
+  fn test_mlq_respects_arrival_time() {
+    let mut scheduler = create_mlq();
+
+    // High priority but NOT arrived
+    scheduler.add_job(create_job_mlq(1, 5, 3, JobType::Foreground, 0));
+
+    // Lower priority but arrived
+    scheduler.add_job(create_job_mlq(2, 0, 3, JobType::Background, 1));
+
+    let job = scheduler.schedule(0).unwrap();
+    // println!("Job: {:?}", job);
+    assert_eq!(job.id, 2);
   }
 }


### PR DESCRIPTION
- Skip jobs that haven't arrived. Because on my previous logic, it works but I didn't considered if jobs arrived
  - That's why on my MLQ logic, regardless if the job arrived or not they are scheduled